### PR TITLE
[REFACTOR] Ensure user_pass not included in export. 

### DIFF
--- a/features/users.feature
+++ b/features/users.feature
@@ -28,6 +28,16 @@ Feature: Site / Network Users Region
       | Admin One      | adminone@example.com  | administrator     |
       | Editor One     | editorone@example.com | editor            |
 
+    When I run `wp dictator export site export.yml`
+    Then STDOUT should contain:
+    """
+    Success: State written to file.
+    """
+    And the export.yml file should not contain:
+    """
+    user_pass:
+    """
+
   Scenario: Impose Network Users
       Given a WP multisite install
       And a network-users.yml file:
@@ -50,3 +60,13 @@ Feature: Site / Network Users Region
         | display_name   | user_email            |
         | Admin One      | adminone@example.com  |
         | Editor One     | editorone@example.com |
+
+      When I run `wp dictator export network export.yml`
+      Then STDOUT should contain:
+      """
+      Success: State written to file.
+      """
+      And the export.yml file should not contain:
+      """
+      user_pass:
+      """

--- a/php/regions/class-users.php
+++ b/php/regions/class-users.php
@@ -35,11 +35,6 @@ abstract class Users extends Region {
 					'_required'     => false,
 					'_get_callback' => 'get_user_value',
 				),
-				'user_pass'    => array(
-					'_type'         => 'text',
-					'_required'     => false,
-					'_get_callback' => 'get_user_value',
-				),
 				'role'         => array(
 					'_type'         => 'text',
 					'_required'     => false,
@@ -149,7 +144,7 @@ abstract class Users extends Region {
 			$user_obj = array(
 				'user_login' => $key,
 				'user_email' => $value['email'], // 'email' is required.
-				'user_pass'  => isset( $value['user_pass'] ) ? $value['user_pass'] : wp_generate_password( 24 ), // if no password supplied, generate random password.
+				'user_pass'  => wp_generate_password( 24 ),
 			);
 			$user_id  = wp_insert_user( $user_obj );
 			if ( is_wp_error( $user_id ) ) {


### PR DESCRIPTION
Although user_pass would have been hashed, it still made little to no
sense including it in the export.

A common use case is to export from one environment to impose on to
another and if not careful this would include the hashed password as the
users password and thus set as the password (it would get re-hashed of
course). Storing passwords in text files is generally frowned upon, so
make sure we don't include it in the export.