### PR TITLE
[BUG] Fix subdomain install adding extra site.

### DIFF
--- a/features/network-sites.feature
+++ b/features/network-sites.feature
@@ -63,3 +63,37 @@ Feature: Network Sites Region
       """
       en_GB
       """
+
+  Scenario: Impose Network Sites with subdomains with main site without a subdomain
+    Given a WP multisite subdomain install
+    And a network-state.yml file:
+      """
+      state: network
+      sites:
+        :
+          title: Main site
+          description: This is the main site with no subdomain required
+          active_theme: p2
+          active_plugins:
+            - akismet/akismet.php
+          timezone_string: Europe/London
+          WPLANG: en_GB
+        sub:
+          title: Sub site
+          description: This is the sub site with a subdomain of 'sub' required
+          active_theme: p2
+          active_plugins:
+            - akismet/akismet.php
+          timezone_string: Europe/London
+          WPLANG: en_GB
+      """
+
+    When I run `wp dictator impose network-state.yml`
+    Then STDOUT should not be empty
+
+    When I run `wp site list --field=url`
+    Then STDOUT should be:
+      """
+      http://example.com/
+      http://sub.example.com/
+      """

--- a/php/regions/class-network-sites.php
+++ b/php/regions/class-network-sites.php
@@ -98,6 +98,9 @@ class Network_Sites extends Region {
 	 * @return true|WP_Error
 	 */
 	public function impose( $key, $value ) {
+		if ( $key === '' ) {
+			$key = get_current_site()->domain;
+		}
 
 		$site = $this->get_site( $key );
 		if ( ! $site ) {
@@ -346,8 +349,12 @@ class Network_Sites extends Region {
 		}
 
 		if ( is_subdomain_install() ) {
-			$path      = '/';
-			$newdomain = $base . '.' . preg_replace( '|^www\.|', '', $network->domain );
+			$path   = '/';
+			$prefix = '';
+			if ( $base !== '' ) {
+				$prefix = $base . '.';
+			}
+			$newdomain = $prefix . preg_replace( '|^www\.|', '', $network->domain );
 		} else {
 			$newdomain = $network->domain;
 			$path      = '/' . trim( $base, '/' ) . '/';


### PR DESCRIPTION
When using a subdomain install, an extra site was being created when the
site key was an empty string, e.g.

example.com
.example.com
sub.example.com

When desired outcome is:

example.com
sub.example.com

This PR updates it so that for subdomain installs, if the site key is an
empty string it will no longer create a site with an empty prefix.